### PR TITLE
更正错误

### DIFF
--- a/Utils/PackHelper.js
+++ b/Utils/PackHelper.js
@@ -46,7 +46,7 @@ module.exports.GetSendTextPack = function(k,iv,text){
 
 function GetEncrypt(k,iv,pack){
     var p = {
-        type : "encrypt",
+        type : "encrypted",
         params : {
             mode : "aes_cbc_pck7padding",
             raw : AES.encrypt(k,iv,pack)


### PR DESCRIPTION
该错误会导致ws发包时出现参数类型错误：
The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received undefined.